### PR TITLE
fixing an object reference not set to a reference exception when using the PCL Postmark override that has parameters

### DIFF
--- a/src/Postmark.PCL/Model/PostmarkMessage.cs
+++ b/src/Postmark.PCL/Model/PostmarkMessage.cs
@@ -38,6 +38,7 @@ namespace PostmarkDotNet
             TextBody = isHtml ? null : body;
             HtmlBody = isHtml ? body : null;
             Headers = new HeaderCollection(headers ?? new Dictionary<string, string>());
+            Attachments = new List<PostmarkMessageAttachment>(0);
         }
 
         /// <summary>


### PR DESCRIPTION
When using the PCL library and creating a PostmarkMessage with constructor parameters you get an object reference exception when trying to add attachments because the Attachments list isn't being initialised in the constructor. 
