### PR TITLE
Added class for delivery webhook payload.

### DIFF
--- a/src/Postmark.Net20/Postmark.Net20.csproj
+++ b/src/Postmark.Net20/Postmark.Net20.csproj
@@ -100,6 +100,9 @@
     <Compile Include="..\postmark\model\PostmarkDeliveryStats.cs">
       <Link>Model\PostmarkDeliveryStats.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkDeliveryWebhookMessage.cs">
+      <Link>Model\PostmarkDeliveryWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\Postmark\Model\PostmarkInboundMessageList.cs">
       <Link>Model\PostmarkInboundMessageList.cs</Link>
     </Compile>

--- a/src/Postmark.Net35/Postmark.Net35.csproj
+++ b/src/Postmark.Net35/Postmark.Net35.csproj
@@ -109,6 +109,9 @@
     <Compile Include="..\Postmark\Model\PostmarkDeliveryStats.cs">
       <Link>Model\PostmarkDeliveryStats.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkDeliveryWebhookMessage.cs">
+      <Link>Model\PostmarkDeliveryWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\Postmark\Model\PostmarkInboundMessageList.cs">
       <Link>Model\PostmarkInboundMessageList.cs</Link>
     </Compile>

--- a/src/Postmark.PCL/Postmark.PCL.csproj
+++ b/src/Postmark.PCL/Postmark.PCL.csproj
@@ -81,6 +81,9 @@
     <Compile Include="..\Postmark\Model\PostmarkDeliveryStats.cs">
       <Link>Model\PostmarkDeliveryStats.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkDeliveryWebhookMessage.cs">
+      <Link>Model\PostmarkDeliveryWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\Postmark\Model\PostmarkInboundMessage.cs">
       <Link>Model\PostmarkInboundMessage.cs</Link>
     </Compile>

--- a/src/Postmark/Model/PostmarkDeliveryWebhookMessage.cs
+++ b/src/Postmark/Model/PostmarkDeliveryWebhookMessage.cs
@@ -1,0 +1,46 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PostmarkDotNet.Webhooks
+{
+    /// <summary>
+    /// Representation of the payload of the delivery webhook
+    /// - http://developer.postmarkapp.com/developer-delivery-webhook.html
+    /// </summary>
+    public class PostmarkDeliveryWebhookMessage
+    {
+        /// <summary>
+        /// The associated server's ID.
+        /// </summary>
+        [JsonProperty("ServerId")]
+        public int ServerID { get; set; }
+
+        /// <summary>
+        /// The associated message's ID.
+        /// </summary>
+        public Guid MessageID { get; set; }
+
+        /// <summary>
+        /// The email address of the recipient.
+        /// </summary>
+        public string Recipient { get; set; }
+
+        /// <summary>
+        /// The delivery tag that was used when the message was sent.
+        /// </summary>
+        public string Tag { get; set; }
+
+        /// <summary>
+        /// The timestamp of when email was delivered.
+        /// </summary>
+        public DateTimeOffset DeliveredAt { get; set; }
+
+        /// <summary>
+        /// The response line received from the destination email server.
+        /// </summary>
+        public string Details { get; set; }
+    }
+}

--- a/src/Postmark/Postmark.csproj
+++ b/src/Postmark/Postmark.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Model\PostmarkBounceSummary.cs" />
     <Compile Include="Model\PostmarkBounceType.cs" />
     <Compile Include="Model\PostmarkDeliveryStats.cs" />
+    <Compile Include="Model\PostmarkDeliveryWebhookMessage.cs" />
     <Compile Include="Model\PostmarkInboundWebhookMessage.cs" />
     <Compile Include="Model\PostmarkInboundMessage.cs" />
     <Compile Include="Model\PostmarkInboundMessageList.cs" />


### PR DESCRIPTION
Added `PostmarkDeliveryWebhookMessage` to match the existing ones for Open, Bounce & Inbound webhooks.

I used the example payload from the [documentation here](http://developer.postmarkapp.com/developer-delivery-webhook.html):
```json
{
  "ServerId": 23,
  "MessageID": "883953f4-6105-42a2-a16a-77a8eac79483",
  "Recipient": "john@example.com",
  "Tag": "welcome-email",
  "DeliveredAt": "2014-08-01T13:28:10.2735393-04:00",
  "Details": "Test delivery webhook details"
}
```