### PR TITLE
Added WebhookMessage classes to all projects.

### DIFF
--- a/src/Postmark.Net20/Postmark.Net20.csproj
+++ b/src/Postmark.Net20/Postmark.Net20.csproj
@@ -97,17 +97,29 @@
     <Compile Include="..\postmark\model\PostmarkBounceType.cs">
       <Link>Model\PostmarkBounceType.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkBounceWebhookMessage.cs">
+      <Link>Model\PostmarkBounceWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\postmark\model\PostmarkDeliveryStats.cs">
       <Link>Model\PostmarkDeliveryStats.cs</Link>
     </Compile>
     <Compile Include="..\Postmark\Model\PostmarkInboundMessageList.cs">
       <Link>Model\PostmarkInboundMessageList.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkInboundWebhookMessage.cs">
+      <Link>Model\PostmarkInboundWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\postmark\model\PostmarkMessage.cs">
       <Link>Model\PostmarkMessage.cs</Link>
     </Compile>
     <Compile Include="..\postmark\model\PostmarkMessageAttachment.cs">
       <Link>Model\PostmarkMessageAttachment.cs</Link>
+    </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkOpensList.cs">
+      <Link>Model\PostmarkOpensList.cs</Link>
+    </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkOpenWebhookMessage.cs">
+      <Link>Model\PostmarkOpenWebhookMessage.cs</Link>
     </Compile>
     <Compile Include="..\Postmark\Model\PostmarkOutboundMessagesList.cs">
       <Link>Model\PostmarkOutboundMessagesList.cs</Link>

--- a/src/Postmark.Net35/Postmark.Net35.csproj
+++ b/src/Postmark.Net35/Postmark.Net35.csproj
@@ -106,17 +106,29 @@
     <Compile Include="..\Postmark\Model\PostmarkBounceType.cs">
       <Link>Model\PostmarkBounceType.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkBounceWebhookMessage.cs">
+      <Link>Model\PostmarkBounceWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\Postmark\Model\PostmarkDeliveryStats.cs">
       <Link>Model\PostmarkDeliveryStats.cs</Link>
     </Compile>
     <Compile Include="..\Postmark\Model\PostmarkInboundMessageList.cs">
       <Link>Model\PostmarkInboundMessageList.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkInboundWebhookMessage.cs">
+      <Link>Model\PostmarkInboundWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\Postmark\Model\PostmarkMessage.cs">
       <Link>Model\PostmarkMessage.cs</Link>
     </Compile>
     <Compile Include="..\Postmark\Model\PostmarkMessageAttachment.cs">
       <Link>Model\PostmarkMessageAttachment.cs</Link>
+    </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkOpensList.cs">
+      <Link>Model\PostmarkOpensList.cs</Link>
+    </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkOpenWebhookMessage.cs">
+      <Link>Model\PostmarkOpenWebhookMessage.cs</Link>
     </Compile>
     <Compile Include="..\Postmark\Model\PostmarkOutboundMessagesList.cs">
       <Link>Model\PostmarkOutboundMessagesList.cs</Link>

--- a/src/Postmark.PCL/Postmark.PCL.csproj
+++ b/src/Postmark.PCL/Postmark.PCL.csproj
@@ -75,6 +75,9 @@
     <Compile Include="..\Postmark\Model\PostmarkBounceType.cs">
       <Link>Model\PostmarkBounceType.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkBounceWebhookMessage.cs">
+      <Link>Model\PostmarkBounceWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\Postmark\Model\PostmarkCompleteSenderSignature.cs">
       <Link>Model\PostmarkCompleteSenderSignature.cs</Link>
     </Compile>
@@ -93,11 +96,17 @@
     <Compile Include="..\Postmark\Model\PostmarkInboundRuleTriggerList.cs">
       <Link>Model\PostmarkInboundRuleTriggerList.cs</Link>
     </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkInboundWebhookMessage.cs">
+      <Link>Model\PostmarkInboundWebhookMessage.cs</Link>
+    </Compile>
     <Compile Include="..\Postmark\Model\PostmarkMessageAttachment.cs">
       <Link>Model\PostmarkMessageAttachment.cs</Link>
     </Compile>
     <Compile Include="..\Postmark\Model\PostmarkOpensList.cs">
       <Link>Model\PostmarkOpensList.cs</Link>
+    </Compile>
+    <Compile Include="..\Postmark\Model\PostmarkOpenWebhookMessage.cs">
+      <Link>Model\PostmarkOpenWebhookMessage.cs</Link>
     </Compile>
     <Compile Include="..\Postmark\Model\PostmarkOutboundBounceStats.cs">
       <Link>Model\PostmarkOutboundBounceStats.cs</Link>

--- a/src/Postmark/Model/PostmarkInboundWebhookMessage.cs
+++ b/src/Postmark/Model/PostmarkInboundWebhookMessage.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using PostmarkDotNet.Model;
+using System;
 using System.Collections.Generic;
 
 namespace PostmarkDotNet.Webhooks


### PR DESCRIPTION
Added `PostmarkBounceWebhookMessage.cs`, `PostmarkInboundWebhookMessage.cs` and `PostmarkOpenWebhookMessage.cs` to the various projects.

Since `PostmarkOpenWebhookMessage` inherits from `PostmarkOpen`, I've also added `PostmarkOpensList.cs`. This doesn't seem to have caused a problem, although the client in that project doesn't have the methods to use it otherwise.