### PR TITLE
Don't ignore headers argument in PostmarkMessage ctor

### DIFF
--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -30,7 +30,7 @@ namespace PostmarkDotNet
             Subject = subject;
             TextBody = textBody;
             HtmlBody = htmlBody;
-            Headers = headers = new HeaderCollection();
+            Headers = headers ?? new HeaderCollection();
         }
 
         /// <summary>


### PR DESCRIPTION
In the `PostmarkMessage` constructor, set property `Headers` to a new collection only if the `headers` argument is null, otherwise set it to the provided headers collection. As it is now, the passed-in headers are always replaced with a new `HeaderCollection`.