### PR TITLE
Add EnableSmtpApiErrorHooks flag to Servers calls

### DIFF
--- a/src/Postmark.Tests/AdminClientServersTests.cs
+++ b/src/Postmark.Tests/AdminClientServersTests.cs
@@ -25,6 +25,7 @@ namespace Postmark.Tests
         private bool? _rawEmailEnabled;
         private string _bounceHookUrl;
         private string _deliveryHookUrl;
+        private bool? _enableSmtpApiErrorHooks;
 
         protected override void Setup()
         {
@@ -44,6 +45,7 @@ namespace Postmark.Tests
             _postFirstOpenOpenOnly = true;
             _trackOpens = true;
             _inboundSpamThreshold = 30;
+            _enableSmtpApiErrorHooks = true;
         }
 
 
@@ -98,7 +100,7 @@ namespace Postmark.Tests
                 _inboundHookUrl + updatedSuffix, _bounceHookUrl + updatedSuffix,
                 _openHookUrl + updatedSuffix, !newServer.PostFirstOpenOnly,
                 !newServer.TrackOpens, null, 5, null, _clickHookUrl + updatedSuffix,
-                _deliveryHookUrl + updatedSuffix);
+                _deliveryHookUrl + updatedSuffix, _enableSmtpApiErrorHooks);
 
             var retrievedServer = await _adminClient.GetServerAsync(newServer.ID);
 
@@ -117,6 +119,8 @@ namespace Postmark.Tests
             //Assert.Equal(updatedAffix + _inboundDomain, retrievedServer.InboundDomain);
             Assert.Equal(5, retrievedServer.InboundSpamThreshold);
             Assert.NotEqual(newServer.InboundSpamThreshold, retrievedServer.InboundSpamThreshold);
+            Assert.False(newServer.EnableSmtpApiErrorHooks);
+            Assert.Equal(_enableSmtpApiErrorHooks, updatedServer.EnableSmtpApiErrorHooks);
         }
 
         [Fact]
@@ -124,7 +128,7 @@ namespace Postmark.Tests
         {
             var newServer = await _adminClient.CreateServerAsync(_name, _color, _rawEmailEnabled, _smtpActivated,
                 _inboundHookUrl, _bounceHookUrl, _openHookUrl, _postFirstOpenOpenOnly, _trackOpens,
-                null, _inboundSpamThreshold, null, _clickHookUrl, _deliveryHookUrl);
+                null, _inboundSpamThreshold, null, _clickHookUrl, _deliveryHookUrl, _enableSmtpApiErrorHooks);
 
             var retrievedServer = await _adminClient.GetServerAsync(newServer.ID);
 
@@ -141,8 +145,7 @@ namespace Postmark.Tests
             Assert.Equal(_trackOpens, retrievedServer.TrackOpens);
             Assert.True(String.IsNullOrEmpty(retrievedServer.InboundDomain));
             Assert.Equal(_inboundSpamThreshold, retrievedServer.InboundSpamThreshold);
-
-
+            Assert.Equal(_enableSmtpApiErrorHooks, retrievedServer.EnableSmtpApiErrorHooks);
         }
 
         [Fact]

--- a/src/Postmark/Model/PostmarkServer.cs
+++ b/src/Postmark/Model/PostmarkServer.cs
@@ -109,6 +109,11 @@ namespace PostmarkDotNet.Model
         /// </summary>
         public int InboundSpamThreshold { get; set; }
 
+        /// <summary>
+        /// Include SMTP API Errors in error webhooks.
+        /// </summary>
+        public bool EnableSmtpApiErrorHooks { get; set; }
+
     }
 
     /// <summary>

--- a/src/Postmark/PostmarkAdminClient.cs
+++ b/src/Postmark/PostmarkAdminClient.cs
@@ -67,7 +67,7 @@ namespace PostmarkDotNet
             bool? rawEmailEnabled = null, bool? smtpApiActivated = null, string inboundHookUrl = null,
             string bounceHookUrl = null, string openHookUrl = null, bool? postFirstOpenOnly = null,
             bool? trackOpens = null, string inboundDomain = null, int? inboundSpamThreshold = null,
-            LinkTrackingOptions? trackLinks = null, string clickHookUrl = null, string deliveryHookUrl = null)
+            LinkTrackingOptions? trackLinks = null, string clickHookUrl = null, string deliveryHookUrl = null, bool? enableSmtpApiErrorHooks = null)
         {
 
             var body = new Dictionary<string, object>();
@@ -85,6 +85,7 @@ namespace PostmarkDotNet
             body["TrackLinks"] = trackLinks;
             body["ClickHookUrl"] = clickHookUrl;
             body["DeliveryHookUrl"] = deliveryHookUrl;
+            body["EnableSmtpApiErrorHooks"] = enableSmtpApiErrorHooks;
 
             return await this.ProcessRequestAsync<Dictionary<string, object>, PostmarkServer>("/servers/", HttpMethod.Post, body);
         }
@@ -107,12 +108,13 @@ namespace PostmarkDotNet
         /// <param name="trackLinks"></param>
         /// <param name="clickHookUrl"></param>
         /// <param name="deliveryHookUrl"></param>
+        /// <param name="enableSmtpApiErrorHooks"></param>
         /// <returns></returns>
         public async Task<PostmarkServer> EditServerAsync(int serverId, String name = null, string color = null,
             bool? rawEmailEnabled = null, bool? smtpApiActivated = null, string inboundHookUrl = null,
             string bounceHookUrl = null, string openHookUrl = null, bool? postFirstOpenOnly = null,
             bool? trackOpens = null, string inboundDomain = null, int? inboundSpamThreshold = null, 
-            LinkTrackingOptions? trackLinks = null, string clickHookUrl = null, string deliveryHookUrl = null)
+            LinkTrackingOptions? trackLinks = null, string clickHookUrl = null, string deliveryHookUrl = null, bool? enableSmtpApiErrorHooks = null)
         {
 
             var body = new Dictionary<string, object>();
@@ -130,7 +132,7 @@ namespace PostmarkDotNet
             body["TrackLinks"] = trackLinks;
             body["ClickHookUrl"] = clickHookUrl;
             body["DeliveryHookUrl"] = deliveryHookUrl;
-            
+            body["EnableSmtpApiErrorHooks"] = enableSmtpApiErrorHooks;
 
             return await this.ProcessRequestAsync<Dictionary<string, object>, PostmarkServer>
                 ("/servers/" + serverId, HttpMethod.Put, body);


### PR DESCRIPTION
This adds the option to use the EnableSmtpApiErrorHooks flag on Servers