### PR TITLE
Add metadata to sending and searching of outbound messages

### DIFF
--- a/src/Postmark.Tests/ClientBaseFixture.cs
+++ b/src/Postmark.Tests/ClientBaseFixture.cs
@@ -71,6 +71,8 @@ namespace Postmark.Tests
         public static readonly string READ_SELENIUM_TEST_SERVER_TOKEN = ConfigVariable("READ_SELENIUM_TEST_SERVER_TOKEN");
         public static readonly string READ_LINK_TRACKING_TEST_SERVER_TOKEN = ConfigVariable("READ_LINK_TRACKING_TEST_SERVER_TOKEN");
         public static readonly string READ_SELENIUM_OPEN_TRACKING_TOKEN = ConfigVariable("READ_SELENIUM_OPEN_TRACKING_TOKEN");
+        public static readonly string READ_TEST_SENDER_EMAIL_ADDRESS = ConfigVariable("READ_TEST_SENDER_EMAIL_ADDRESS");
+        public static readonly string READ_TEST_RECIPIENT_EMAIL_ADDRESS = ConfigVariable("READ_TEST_RECIPIENT_EMAIL_ADDRESS");
 
         public static readonly string WRITE_ACCOUNT_TOKEN = ConfigVariable("WRITE_ACCOUNT_TOKEN");
         public static readonly string WRITE_TEST_SERVER_TOKEN = ConfigVariable("WRITE_TEST_SERVER_TOKEN");

--- a/src/Postmark.Tests/ClientMessageSearchingTests.cs
+++ b/src/Postmark.Tests/ClientMessageSearchingTests.cs
@@ -64,32 +64,6 @@ namespace Postmark.Tests
             Assert.Equal(baseMessage.MessageID, requestedMessage.MessageID);
         }
 
-        //This is a bad test since it requires a Delay before the message has been saved so that we can retrieve details.
-        //In other tests (for link and click tracking), we have test accounts that have plenty of messages to sample from
-        //We would need to agree on a convetion for metadata and do something similar to avoid having to create and wait for data in this test
-        [Fact]
-        public async void Client_CanSendAndGetOutboundMessageDetailsWithMetadata()
-        {
-            var metadata = new Dictionary<string, string>() {
-                    {"test-metadata", "value-goes-here"},
-                    {"more-metadata", "more-goes-here"}
-                };
-
-            var messageWithMetadata = await _client.SendMessageAsync(READ_TEST_SENDER_EMAIL_ADDRESS,
-                WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
-                String.Format("Integration Test - {0}", TESTING_DATE),
-                String.Format("Plain text body, {0}", TESTING_DATE),
-                String.Format("Testing the Postmark .net client, <b>{0}</b>", TESTING_DATE),
-                null,
-                metadata
-                );
-
-            await Task.Delay(TimeSpan.FromSeconds(2));
-
-            var details = await _client.GetOutboundMessageDetailsAsync(messageWithMetadata.MessageID.ToString());
-            Assert.Equal(details.Metadata, metadata);
-        }
-
         [Fact]
         public async void Client_CanGetMessageDump()
         {

--- a/src/Postmark.Tests/ClientMessageSearchingTests.cs
+++ b/src/Postmark.Tests/ClientMessageSearchingTests.cs
@@ -1,5 +1,6 @@
 ﻿using Xunit;
 using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
 using PostmarkDotNet;
@@ -61,6 +62,32 @@ namespace Postmark.Tests
 
             Assert.NotNull(requestedMessage);
             Assert.Equal(baseMessage.MessageID, requestedMessage.MessageID);
+        }
+
+        //This is a bad test since it requires a Delay before the message has been saved so that we can retrieve details.
+        //In other tests (for link and click tracking), we have test accounts that have plenty of messages to sample from
+        //We would need to agree on a convetion for metadata and do something similar to avoid having to create and wait for data in this test
+        [Fact]
+        public async void Client_CanSendAndGetOutboundMessageDetailsWithMetadata()
+        {
+            var metadata = new Dictionary<string, string>() {
+                    {"test-metadata", "value-goes-here"},
+                    {"more-metadata", "more-goes-here"}
+                };
+
+            var messageWithMetadata = await _client.SendMessageAsync(READ_TEST_SENDER_EMAIL_ADDRESS,
+                WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
+                String.Format("Integration Test - {0}", TESTING_DATE),
+                String.Format("Plain text body, {0}", TESTING_DATE),
+                String.Format("Testing the Postmark .net client, <b>{0}</b>", TESTING_DATE),
+                null,
+                metadata
+                );
+
+            await Task.Delay(TimeSpan.FromSeconds(2));
+
+            var details = await _client.GetOutboundMessageDetailsAsync(messageWithMetadata.MessageID.ToString());
+            Assert.Equal(details.Metadata, metadata);
         }
 
         [Fact]

--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -26,6 +26,10 @@ namespace Postmark.Tests
                 new Dictionary<string, string>()
                 {
                   {  "X-Integration-Testing" , TESTING_DATE.ToString("o")}
+                },
+                new Dictionary<string, string>() {
+                    {"test-metadata", "value-goes-here"},
+                    {"more-metadata", "more-goes-here"}
                 });
 
             Assert.Equal(PostmarkStatus.Success, result.Status);
@@ -61,6 +65,7 @@ namespace Postmark.Tests
                 Headers = new HeaderCollection(){
                   new MailHeader( "X-Integration-Testing-Postmark-Type-Message" , TESTING_DATE.ToString("o"))
                 },
+                Metadata = new Dictionary<string, string>() { { "something-interesting", "very-interesting" }, {"client-id", "42"} },
                 ReplyTo = inboundAddress,
                 Tag = "integration-testing"
             };
@@ -89,7 +94,5 @@ namespace Postmark.Tests
             Assert.True(results.All(k => k.Status == PostmarkStatus.Success));
             Assert.Equal(messages.Length, results.Count());
         }
-
-
     }
 }

--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading.Tasks;
 
 namespace Postmark.Tests
 {
@@ -13,6 +14,50 @@ namespace Postmark.Tests
         protected override void Setup()
         {
             _client = new PostmarkClient(WRITE_TEST_SERVER_TOKEN);
+        }
+
+        //This is a bad test since it requires a Delay before the message has been saved so that we can retrieve details.
+        //In other tests (for link and click tracking), we have test accounts that have plenty of messages to sample from
+        //We would need to agree on a convetion for metadata and do something similar to avoid having to create and wait for data in this test
+        [Fact]
+        public async void Client_CanSendAndGetOutboundMessageDetailsWithMetadata()
+        {
+            var metadata = new Dictionary<string, string>() {
+                    {"test-metadata", "value-goes-here"},
+                    {"more-metadata", "more-goes-here"}
+                };
+
+            var sendResult = await _client.SendMessageAsync(
+                WRITE_TEST_SENDER_EMAIL_ADDRESS,
+                WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
+                $"Integration Test - {TESTING_DATE}",
+                $"Plain text body, {TESTING_DATE}",
+                $"Testing the Postmark .net client, <b>{TESTING_DATE}</b>",
+                null,
+                metadata
+                );
+
+            IDictionary<string, string> storedDetails = null;
+
+            Func<Task> query = async()=>{
+                try{
+                    while(true){
+                        var details = await _client
+                            .GetOutboundMessageDetailsAsync(sendResult.MessageID.ToString());
+                        storedDetails = details.Metadata;
+                        if(storedDetails != null) return; 
+                        await Task.Delay(TimeSpan.FromSeconds(2));
+                    }
+                }catch{
+
+                }
+                return;
+            };
+
+            //wait up to 30 seconds, checking every two seconds for the metadata.
+            await Task.WhenAny(Task.Delay(TimeSpan.FromSeconds(30)), query());
+
+            Assert.Equal(storedDetails, metadata);
         }
 
         [Fact]

--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -22,8 +22,7 @@ namespace Postmark.Tests
             // prime the test for a future go-round (this ensures this test can run quickly,
             // but it's also a bit of a hack.
             var metadata = new Dictionary<string, string>() {
-                    {"client-test", "value-goes-here"},
-                    {"client-test2", "more-goes-here"}
+                    {"client-test", "value-goes-here"}
                 };
 
             await _client.SendMessageAsync(

--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -110,7 +110,7 @@ namespace Postmark.Tests
                 Headers = new HeaderCollection(){
                   new MailHeader( "X-Integration-Testing-Postmark-Type-Message" , TESTING_DATE.ToString("o"))
                 },
-                Metadata = new Dictionary<string, string>() { { "something-interesting", "very-interesting" }, {"client-id", "42"} },
+                Metadata = new Dictionary<string, string>() { { "stuff", "very-interesting" }, {"client-id", "42"} },
                 ReplyTo = inboundAddress,
                 Tag = "integration-testing"
             };

--- a/src/Postmark/Model/PostmarkBounceWebhookMessage.cs
+++ b/src/Postmark/Model/PostmarkBounceWebhookMessage.cs
@@ -1,4 +1,6 @@
-﻿namespace PostmarkDotNet.Webhooks
+﻿using System.Collections.Generic;
+
+namespace PostmarkDotNet.Webhooks
 {
 
     /// <summary>
@@ -12,5 +14,9 @@
         /// <value>The type code</value>
         public int TypeCode { get; set; }
 
+        /// <summary>
+        /// The metadata for the bounced message.
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Postmark/Model/PostmarkDeliveryWebhookMessage.cs
+++ b/src/Postmark/Model/PostmarkDeliveryWebhookMessage.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace PostmarkDotNet.Webhooks
 {
@@ -39,5 +40,10 @@ namespace PostmarkDotNet.Webhooks
         /// The response line received from the destination email server.
         /// </summary>
         public string Details { get; set; }
+
+        /// <summary>
+        /// The metadata for this message.
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Postmark/Model/PostmarkInboundWebhookMessage.cs
+++ b/src/Postmark/Model/PostmarkInboundWebhookMessage.cs
@@ -115,5 +115,10 @@ namespace PostmarkDotNet.Webhooks
         /// A list of Attachments from the message, fully parsed as Attachment classes
         /// </summary>
         public List<Attachment> Attachments { get; set; }
+
+        /// <summary>
+        /// The metadata for this message.
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; set; }
     }
 }

--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -21,16 +21,17 @@ namespace PostmarkDotNet
         /// <param name="textBody">The Plain Text Body to be used for the message, this may be null if HtmlBody is set.</param>
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name = "headers">A collection of additional mail headers to send with the message. (optional)</param>
-        public PostmarkMessage(string from, string to, string subject, string textBody, string htmlBody, HeaderCollection headers = null)
+        /// <param name = "metadata">A dictionary of metadata to send with the message. (optional)</param>
+        public PostmarkMessage(string from, string to, string subject, string textBody, string htmlBody, HeaderCollection headers = null, IDictionary<string, string> metadata = null)
             : base()
         {
-            
             From = from;
             To = to;
             Subject = subject;
             TextBody = textBody;
             HtmlBody = htmlBody;
             Headers = headers ?? new HeaderCollection();
+            Metadata = metadata;
         }
 
         /// <summary>

--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -22,8 +22,9 @@ namespace PostmarkDotNet
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name = "headers">A collection of additional mail headers to send with the message. (optional)</param>
         /// <param name = "metadata">A dictionary of metadata to send with the message. (optional)</param>
-        public PostmarkMessage(string from, string to, string subject, string textBody, string htmlBody, HeaderCollection headers = null, IDictionary<string, string> metadata = null)
-            : base()
+        public PostmarkMessage(string from, string to, string subject, string textBody, string htmlBody,
+            HeaderCollection headers = null, 
+            IDictionary<string, string> metadata = null): base()
         {
             From = from;
             To = to;

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -69,6 +69,11 @@ namespace PostmarkDotNet
         public HeaderCollection Headers { get; set; } = new HeaderCollection();
 
         /// <summary>
+        ///   A dictionary of optional metadata.
+        /// </summary>
+        public IDictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
         ///   A collection of optional file attachments.
         /// </summary>
         public ICollection<PostmarkMessageAttachment> Attachments { get; set; }

--- a/src/Postmark/Model/PostmarkOpenWebhookMessage.cs
+++ b/src/Postmark/Model/PostmarkOpenWebhookMessage.cs
@@ -27,6 +27,11 @@ namespace PostmarkDotNet.Webhooks
         /// </summary>
         /// <value>Email address of the recipient</value>
         public string Recipient { get; set; }
+
+        /// <summary>
+        /// The metadata for the opened message.
+        /// </summary>
+        public Dictionary<string, string> Metadata { get; set; }
     }
 
 }

--- a/src/Postmark/Model/PostmarkOutboundMessagesList.cs
+++ b/src/Postmark/Model/PostmarkOutboundMessagesList.cs
@@ -23,6 +23,7 @@ namespace PostmarkDotNet.Model
         public string Subject { get; set; }
         public List<string> Attachments { get; set; }
         public string Status { get; set; }
+        public Dictionary<string, string> Metadata { get; set; }
     }
 
     public class OutboundMessageDetail : Message

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -974,10 +974,7 @@ namespace PostmarkDotNet
             {
                 email.Headers = new HeaderCollection(headers);
             }
-            if(metadata != null)
-            {
-                email.Metadata = metadata;
-            }
+            email.Metadata = metadata;
             if (attachments != null)
             {
                 email.Attachments = attachments;

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -186,8 +186,13 @@ namespace PostmarkDotNet
             parameters["todate"] = toDate;
             parameters["fromdate"] = fromDate;
             parameters["status"] = status.ToString().ToLower();
-            parameters["metadata"] = FormatMetadataSearchString(metadata);
-           
+
+            if(metadata != null){
+                foreach(var a in metadata){
+                    parameters[$"metadata_{a.Key}"] = a.Value;
+                }
+            }
+
             return await ProcessNoBodyRequestAsync<PostmarkOutboundMessageList>("/messages/outbound", parameters);
         }
 
@@ -994,13 +999,6 @@ namespace PostmarkDotNet
 
             return await ProcessRequestAsync<Dictionary<string, object>, TemplateValidationResponse>("/templates/validate", HttpMethod.Post, body);
         }
-
-        string FormatMetadataSearchString(IDictionary<string, string> metadata)
-        {
-            return string.Join("&", metadata.Select(m => $"metadata_{m.Key}={m.Value}"));
-        }
-
-
         #endregion
     }
 }

--- a/src/Postmark/PostmarkClientExtensions.cs
+++ b/src/Postmark/PostmarkClientExtensions.cs
@@ -27,9 +27,12 @@ namespace PostmarkDotNet
         /// <param name="headers">A collection of additional mail headers to send with the message.</param>
         /// <returns>A <see cref = "PostmarkResponse" /> with details about the transaction.</returns>
         public static async Task<PostmarkResponse> SendMessageAsync(this PostmarkClient client,
-            string from, string to, string subject, string textBody, string htmlBody, IDictionary<string, string> headers = null, IDictionary<string, string> metadata = null)
+            string from, string to, string subject, string textBody, string htmlBody,
+             IDictionary<string, string> headers = null, 
+             IDictionary<string, string> metadata = null)
         {
-            var message = new PostmarkMessage(from, to, subject, textBody, htmlBody, new HeaderCollection(headers), metadata);
+            var message = new PostmarkMessage(from, to, subject, textBody, htmlBody, 
+            new HeaderCollection(headers), metadata);
             return await client.SendMessageAsync(message);
         }
 

--- a/src/Postmark/PostmarkClientExtensions.cs
+++ b/src/Postmark/PostmarkClientExtensions.cs
@@ -27,9 +27,9 @@ namespace PostmarkDotNet
         /// <param name="headers">A collection of additional mail headers to send with the message.</param>
         /// <returns>A <see cref = "PostmarkResponse" /> with details about the transaction.</returns>
         public static async Task<PostmarkResponse> SendMessageAsync(this PostmarkClient client,
-            string from, string to, string subject, string textBody, string htmlBody, IDictionary<string, string> headers = null)
+            string from, string to, string subject, string textBody, string htmlBody, IDictionary<string, string> headers = null, IDictionary<string, string> metadata = null)
         {
-            var message = new PostmarkMessage(from, to, subject, textBody, htmlBody, new HeaderCollection(headers));
+            var message = new PostmarkMessage(from, to, subject, textBody, htmlBody, new HeaderCollection(headers), metadata);
             return await client.SendMessageAsync(message);
         }
 


### PR DESCRIPTION
This adds the Metadata property to PostmarkMessage to allow sending messages with metadata. Also, GetOutboundMessagesAsync now has an optional argument for searching on metadata.