### PR TITLE
Changing TrackLinks to allow Null

### DIFF
--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -77,7 +77,19 @@ namespace Postmark.Tests
             Assert.NotEqual(Guid.Empty, result.MessageID);
         }
 
-        private PostmarkMessage ConstructMessage(string inboundAddress, int number = 0)
+        [Fact]
+        public async void Client_CanSendAPostmarkMessageWithEmptyTrackLinks()
+        {
+            var inboundAddress = (await _client.GetServerAsync()).InboundAddress;
+            var message = ConstructMessage(inboundAddress, 0, null);
+            var result = await _client.SendMessageAsync(message);
+
+            Assert.Equal(PostmarkStatus.Success, result.Status);
+            Assert.Equal(0, result.ErrorCode);
+            Assert.NotEqual(Guid.Empty, result.MessageID);
+        }
+
+        private PostmarkMessage ConstructMessage(string inboundAddress, int number = 0, LinkTrackingOptions? trackLinks = LinkTrackingOptions.HtmlAndText)
         {
             var message = new PostmarkMessage()
             {
@@ -89,7 +101,7 @@ namespace Postmark.Tests
                 HtmlBody = String.Format("Testing the Postmark .net client, <b>{0}</b>", TESTING_DATE),
                 TextBody = "This is plain text.",
                 TrackOpens = true,
-                TrackLinks = LinkTrackingOptions.HtmlAndText,
+                TrackLinks = trackLinks,
                 Headers = new HeaderCollection(){
                   new MailHeader( "X-Integration-Testing-Postmark-Type-Message" , TESTING_DATE.ToString("o"))
                 },

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -16,7 +16,6 @@ namespace PostmarkDotNet
         public PostmarkMessageBase()
         {
             Attachments = new List<PostmarkMessageAttachment>(0);
-            TrackLinks = LinkTrackingOptions.None;
         }
 
         /// <summary>
@@ -61,7 +60,7 @@ namespace PostmarkDotNet
         /// </remarks>
         public bool? TrackOpens { get; set; }
 
-        public LinkTrackingOptions TrackLinks { get; set; }
+        public LinkTrackingOptions? TrackLinks { get; set; }
 
         /// <summary>
         ///   A collection of optional message headers.

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -16,6 +16,7 @@ namespace PostmarkDotNet
         public PostmarkMessageBase()
         {
             Attachments = new List<PostmarkMessageAttachment>(0);
+            TrackLinks = LinkTrackingOptions.None;
         }
 
         /// <summary>


### PR DESCRIPTION
Hey!

I'm going to grade to a newer version of the package to start using `TrackLinks` per message level which is currently not available on the version we use. When I was looking through [their docs](https://postmarkapp.com/developer/user-guide/tracking-links#enabling-link-tracking) I noticed "This setting overrides the default setting for the server.". In our scenario we have PostMark servers with the TrackLinks option set to various option on each one on sever level, and our goal it to
1) Change the behavior to `None` for one specific message
2) Ensure we don't override all other settings on all other servers.

The current implementation makes me think that we the 3 options that we have we'll not have an ability to use Server level setting, we'll always be sending one of 3 options per message level explicitly. So I'd like to propose a change to allow sending null in that option to not override server setting. I made more digging into their FAQs and found that it seems to be a valid option according to what's said [here](https://postmarkapp.com/support/article/1058-how-do-i-enable-link-tracking):
![image](https://user-images.githubusercontent.com/13271521/55324218-11101f00-548a-11e9-876d-204e128cdea1.png)

Please let me know how it sounds.

A couple of side notes:
1) I couldn't make the UnitTest run locally without the configuration init errors. I found some comments describing that this's intended that the configuration is not stored in the repo, so I assume this's OK.
2) I left the message default value to be set to `None` here and not changed it to null intentionally to ensure I don't introduce backward incompatible/breaking change. Though I think it might be good to change to to `null` with one of major release eventually.