### PR TITLE
Task/add message stream to sending api

### DIFF
--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -97,11 +97,13 @@ namespace Postmark.Tests
             var message = ConstructMessage(inboundAddress, 0, null);
             message.MessageStream = "outbound";
 
+            // Testing the default transactional stream
             var result = await _client.SendMessageAsync(message);
             Assert.Equal(PostmarkStatus.Success, result.Status);
             Assert.Equal(0, result.ErrorCode);
             Assert.NotEqual(Guid.Empty, result.MessageID);
 
+            // Testing an invalid non-existing stream
             message.MessageStream = "unknown-stream";
 
             await Assert.ThrowsAsync<PostmarkValidationException>(() => _client.SendMessageAsync(message));

--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -204,7 +204,7 @@ namespace Postmark.Tests
         public async void ClientCanSendWithTemplate()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, PostmarkMessageBase.DefaultTransactionalStream, false);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 
@@ -212,7 +212,7 @@ namespace Postmark.Tests
         public async void ClientCanSendTemplateWithStringModel()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, PostmarkMessageBase.DefaultTransactionalStream, false);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 

--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -204,8 +204,7 @@ namespace Postmark.Tests
         public async void ClientCanSendWithTemplate()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, 
-                WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 
@@ -213,8 +212,7 @@ namespace Postmark.Tests
         public async void ClientCanSendTemplateWithStringModel()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", 
-                WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 

--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -204,7 +204,8 @@ namespace Postmark.Tests
         public async void ClientCanSendWithTemplate()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, 
+                WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 
@@ -212,7 +213,8 @@ namespace Postmark.Tests
         public async void ClientCanSendTemplateWithStringModel()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", 
+                WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 

--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -204,7 +204,7 @@ namespace Postmark.Tests
         public async void ClientCanSendWithTemplate()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, PostmarkMessageBase.DefaultTransactionalStream, false);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, new { name = "Andrew" }, WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 
@@ -212,7 +212,7 @@ namespace Postmark.Tests
         public async void ClientCanSendTemplateWithStringModel()
         {
             var template = await _client.CreateTemplateAsync("test template name", "test subject", "test html body");
-            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, PostmarkMessageBase.DefaultTransactionalStream, false);
+            var sendResult = await _client.SendEmailWithTemplateAsync(template.TemplateId, "{ \"name\" : \"Andrew\" }", WRITE_TEST_SENDER_EMAIL_ADDRESS, WRITE_TEST_SENDER_EMAIL_ADDRESS, false, messageStream: PostmarkMessageBase.DefaultTransactionalStream);
             Assert.NotEqual(Guid.Empty, sendResult.MessageID);
         }
 

--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -33,7 +33,7 @@ namespace PostmarkDotNet
             HtmlBody = htmlBody;
             Headers = headers ?? new HeaderCollection();
             Metadata = metadata;
-            MessageStream = messageStream ?? DefaultTransactionalStream;
+            MessageStream = messageStream;
         }
 
         /// <summary>

--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -22,9 +22,9 @@ namespace PostmarkDotNet
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name = "headers">A collection of additional mail headers to send with the message. (optional)</param>
         /// <param name = "metadata">A dictionary of metadata to send with the message. (optional)</param>
+        /// <param name="messageStream">The message stream used to send this message. If not provided, the default transactional stream "outbound" will be used. (optional)</param>
         public PostmarkMessage(string from, string to, string subject, string textBody, string htmlBody,
-            HeaderCollection headers = null, 
-            IDictionary<string, string> metadata = null): base()
+            HeaderCollection headers = null, IDictionary<string, string> metadata = null, string messageStream = null) : base()
         {
             From = from;
             To = to;
@@ -33,6 +33,7 @@ namespace PostmarkDotNet
             HtmlBody = htmlBody;
             Headers = headers ?? new HeaderCollection();
             Metadata = metadata;
+            MessageStream = messageStream ?? DefaultTransactionalStream;
         }
 
         /// <summary>

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -11,11 +11,6 @@ namespace PostmarkDotNet
     public abstract class PostmarkMessageBase
     {
         /// <summary>
-        /// The default transactional stream available on each server.
-        /// </summary>
-        public static readonly string DefaultTransactionalStream = "outbound";
-
-        /// <summary>
         ///   Initializes a new instance of the <see cref = "PostmarkMessage" /> class.
         /// </summary>
         public PostmarkMessageBase()
@@ -27,7 +22,7 @@ namespace PostmarkDotNet
         /// <summary>
         ///   The message stream used to send this message.
         /// </summary>
-        public string MessageStream { get; set; } = DefaultTransactionalStream;
+        public string MessageStream { get; set; }
 
         /// <summary>
         ///   The sender's email address.

--- a/src/Postmark/Model/PostmarkMessageBase.cs
+++ b/src/Postmark/Model/PostmarkMessageBase.cs
@@ -11,6 +11,11 @@ namespace PostmarkDotNet
     public abstract class PostmarkMessageBase
     {
         /// <summary>
+        /// The default transactional stream available on each server.
+        /// </summary>
+        public static readonly string DefaultTransactionalStream = "outbound";
+
+        /// <summary>
         ///   Initializes a new instance of the <see cref = "PostmarkMessage" /> class.
         /// </summary>
         public PostmarkMessageBase()
@@ -18,6 +23,11 @@ namespace PostmarkDotNet
             Attachments = new List<PostmarkMessageAttachment>(0);
             TrackLinks = LinkTrackingOptions.None;
         }
+
+        /// <summary>
+        ///   The message stream used to send this message.
+        /// </summary>
+        public string MessageStream { get; set; } = DefaultTransactionalStream;
 
         /// <summary>
         ///   The sender's email address.

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -858,6 +858,7 @@ namespace PostmarkDotNet
 
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(string templateAlias, T templateModel,
             string to, string from,
+            string messageStream = null,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
@@ -865,12 +866,13 @@ namespace PostmarkDotNet
             IDictionary<string, string> metadata = null,
             params PostmarkMessageAttachment[] attachments)
         {
-            return await InternalSendEmailWithTemplateAsync(templateAlias, templateModel, to, from, inlineCss, cc,
+            return await InternalSendEmailWithTemplateAsync(templateAlias, templateModel, messageStream, to, from, inlineCss, cc,
             bcc, replyTo, trackOpens, headers, metadata, attachments);
         }
 
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(long templateId, T templateModel,
             string to, string from,
+            string messageStream = null,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
@@ -878,11 +880,12 @@ namespace PostmarkDotNet
             IDictionary<string, string> metadata = null,
             params PostmarkMessageAttachment[] attachments)
         {
-            return await InternalSendEmailWithTemplateAsync(templateId, templateModel, to, from, inlineCss, cc,
+            return await InternalSendEmailWithTemplateAsync(templateId, templateModel, messageStream, to, from, inlineCss, cc,
             bcc, replyTo, trackOpens, headers, metadata, attachments);
         }
 
         private async Task<PostmarkResponse> InternalSendEmailWithTemplateAsync<T>(object templateReference, T templateModel,
+            string messageStream,
             string to, string from,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
@@ -902,6 +905,7 @@ namespace PostmarkDotNet
                 email.TemplateAlias = (string)templateReference;
             }
             email.TemplateModel = templateModel;
+            email.MessageStream = messageStream;
             email.To = to;
             email.From = from;
             if (inlineCss.HasValue)

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -905,7 +905,7 @@ namespace PostmarkDotNet
                 email.TemplateAlias = (string)templateReference;
             }
             email.TemplateModel = templateModel;
-            email.MessageStream = messageStream ?? PostmarkMessageBase.DefaultTransactionalStream;
+            email.MessageStream = messageStream;
             email.To = to;
             email.From = from;
             if (inlineCss.HasValue)

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -858,40 +858,40 @@ namespace PostmarkDotNet
 
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(string templateAlias, T templateModel,
             string to, string from,
-            string messageStream = null,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
             IDictionary<string, string> headers = null,
             IDictionary<string, string> metadata = null,
+            string messageStream = null,
             params PostmarkMessageAttachment[] attachments)
         {
-            return await InternalSendEmailWithTemplateAsync(templateAlias, templateModel, messageStream, to, from, inlineCss, cc,
-            bcc, replyTo, trackOpens, headers, metadata, attachments);
+            return await InternalSendEmailWithTemplateAsync(templateAlias, templateModel, to, from, inlineCss, cc,
+            bcc, replyTo, trackOpens, headers, metadata, messageStream, attachments);
         }
 
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(long templateId, T templateModel,
             string to, string from,
-            string messageStream = null,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
             IDictionary<string, string> headers = null,
             IDictionary<string, string> metadata = null,
+            string messageStream = null,
             params PostmarkMessageAttachment[] attachments)
         {
-            return await InternalSendEmailWithTemplateAsync(templateId, templateModel, messageStream, to, from, inlineCss, cc,
-            bcc, replyTo, trackOpens, headers, metadata, attachments);
+            return await InternalSendEmailWithTemplateAsync(templateId, templateModel, to, from, inlineCss, cc,
+            bcc, replyTo, trackOpens, headers, metadata, messageStream, attachments);
         }
 
         private async Task<PostmarkResponse> InternalSendEmailWithTemplateAsync<T>(object templateReference, T templateModel,
-            string messageStream,
             string to, string from,
             bool? inlineCss = null, string cc = null,
             string bcc = null, string replyTo = null,
             bool? trackOpens = null,
             IDictionary<string, string> headers = null,
             IDictionary<string, string> metadata = null,
+            string messageStream = null,
             params PostmarkMessageAttachment[] attachments)
         {
 
@@ -905,7 +905,7 @@ namespace PostmarkDotNet
                 email.TemplateAlias = (string)templateReference;
             }
             email.TemplateModel = templateModel;
-            email.MessageStream = messageStream;
+            email.MessageStream = messageStream ?? PostmarkMessageBase.DefaultTransactionalStream;
             email.To = to;
             email.From = from;
             if (inlineCss.HasValue)

--- a/src/Postmark/PostmarkClientExtensions.cs
+++ b/src/Postmark/PostmarkClientExtensions.cs
@@ -24,7 +24,7 @@ namespace PostmarkDotNet
         /// <param name="textBody">The Plain Text Body to be used for the message, this may be null if HtmlBody is set.</param>
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name="headers">A collection of additional mail headers to send with the message.</param>
-        /// <param name="messageStream">The message stream used to send this message</param>
+        /// <param name="messageStream">The message stream used to send this message.</param>
         /// <returns>A <see cref = "PostmarkResponse" /> with details about the transaction.</returns>
         public static async Task<PostmarkResponse> SendMessageAsync(this PostmarkClient client,
             string from, string to, string subject, string textBody, string htmlBody,

--- a/src/Postmark/PostmarkClientExtensions.cs
+++ b/src/Postmark/PostmarkClientExtensions.cs
@@ -10,7 +10,6 @@ namespace PostmarkDotNet
     /// </summary>
     public static class PostmarkClientExtensions
     {
-
         /// <summary>
         /// Sends a message through the Postmark API.
         /// All email addresses must be valid, and the sender must be
@@ -25,14 +24,16 @@ namespace PostmarkDotNet
         /// <param name="textBody">The Plain Text Body to be used for the message, this may be null if HtmlBody is set.</param>
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name="headers">A collection of additional mail headers to send with the message.</param>
+        /// <param name="messageStream">The message stream used to send this message</param>
         /// <returns>A <see cref = "PostmarkResponse" /> with details about the transaction.</returns>
         public static async Task<PostmarkResponse> SendMessageAsync(this PostmarkClient client,
             string from, string to, string subject, string textBody, string htmlBody,
-             IDictionary<string, string> headers = null, 
-             IDictionary<string, string> metadata = null)
+             IDictionary<string, string> headers = null,
+             IDictionary<string, string> metadata = null,
+             string messageStream = null)
         {
-            var message = new PostmarkMessage(from, to, subject, textBody, htmlBody, 
-            new HeaderCollection(headers), metadata);
+            var message = new PostmarkMessage(from, to, subject, textBody, htmlBody,
+            new HeaderCollection(headers), metadata, messageStream);
             return await client.SendMessageAsync(message);
         }
 


### PR DESCRIPTION
- Adds `MessageStream` field to the email sending methods
- `MessageStream` API will be added in a subsequent PR (after enabling it globally)