### PR TITLE
Use long Bounce IDs

### DIFF
--- a/src/Postmark/Model/PostmarkBounce.cs
+++ b/src/Postmark/Model/PostmarkBounce.cs
@@ -14,7 +14,7 @@ namespace PostmarkDotNet
         ///   This is used for other API calls that require the ID.
         /// </summary>
         /// <value>The ID</value>
-        public int ID { get; set; }
+        public long ID { get; set; }
 
         /// <summary>
         ///   The <see cref = "PostmarkBounceType" /> for this bounce.

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -117,7 +117,7 @@ namespace PostmarkDotNet
         /// <param name="bounceId">The bounce ID of the bounce to retrieve.</param>
         /// <returns></returns>
         /// <seealso href = "http://developer.postmarkapp.com/bounces" />
-        public async Task<PostmarkBounce> GetBounceAsync(int bounceId)
+        public async Task<PostmarkBounce> GetBounceAsync(long bounceId)
         {
             return await ProcessNoBodyRequestAsync<PostmarkBounce>("/bounces/" + bounceId);
         }
@@ -129,7 +129,7 @@ namespace PostmarkDotNet
         /// <param name="bounceId">The bounce ID of the bounce dump to retrieve.</param>
         /// <returns></returns>
         /// <seealso href = "http://developer.postmarkapp.com/bounces" />
-        public async Task<PostmarkBounceDump> GetBounceDumpAsync(int bounceId)
+        public async Task<PostmarkBounceDump> GetBounceDumpAsync(long bounceId)
         {
             return await ProcessNoBodyRequestAsync<PostmarkBounceDump>("/bounces/" + bounceId + "/dump");
         }
@@ -140,7 +140,7 @@ namespace PostmarkDotNet
         /// <param name="bounceId">The bounce ID of the bounce to Activate</param>
         /// <returns></returns>
         /// <seealso href = "http://developer.postmarkapp.com/bounces" />
-        public async Task<PostmarkBounceActivation> ActivateBounceAsync(int bounceId)
+        public async Task<PostmarkBounceActivation> ActivateBounceAsync(long bounceId)
         {
             return await ProcessNoBodyRequestAsync<PostmarkBounceActivation>("/bounces/" + bounceId + "/activate", verb: HttpMethod.Put);
         }


### PR DESCRIPTION
- This PR updates the `Bounce` `ID` type from `int` to `long`
- This is pretty simple and straightforward, but will require a major version release.

**Sidenote:**
- We could consider doing some other changes as well as part of this major release, such as trimming down on the number of arguments in the `PostmarkMessage` constructor to only the "basic" ones.

@atheken do you have any other suggestions for potentially breaking changes that would be suitable to be included in this next major release?