### PR TITLE
Fix `PostmarkInboundMessage.Attachment` model

### DIFF
--- a/src/Postmark/Model/PostmarkInboundMessage.cs
+++ b/src/Postmark/Model/PostmarkInboundMessage.cs
@@ -152,8 +152,7 @@ namespace PostmarkDotNet
         public string Name { get; set; }
         public string Content { get; set; }
         public string ContentType { get; set; }
-        public string ContentLength { get; set; }
-        public string ContentID { get; set; }
+        public int ContentLength { get; set; }
     }
 
 }

--- a/src/Postmark/Model/PostmarkInboundMessage.cs
+++ b/src/Postmark/Model/PostmarkInboundMessage.cs
@@ -153,6 +153,7 @@ namespace PostmarkDotNet
         public string Content { get; set; }
         public string ContentType { get; set; }
         public int ContentLength { get; set; }
+        public string ContentID { get; set; }
     }
 
 }

--- a/src/Postmark/Model/PostmarkInboundMessage.cs
+++ b/src/Postmark/Model/PostmarkInboundMessage.cs
@@ -152,7 +152,8 @@ namespace PostmarkDotNet
         public string Name { get; set; }
         public string Content { get; set; }
         public string ContentType { get; set; }
-        public int ContentLength { get; set; }
+        public long ContentLength { get; set; }
+
         public string ContentID { get; set; }
     }
 


### PR DESCRIPTION
Looking at the demo from https://postmarkapp.com/developer/webhooks/inbound-webhook it seems like the Attachment class has changed a bit.

Updating a simple project to `netcoreapp3.1` with nullable reference types disabled, broke our setup.