### PR TITLE
Add support for sending batch templated messages

### DIFF
--- a/src/Postmark.Tests/ClientTemplateTests.cs
+++ b/src/Postmark.Tests/ClientTemplateTests.cs
@@ -222,7 +222,8 @@ namespace Postmark.Tests
         {
             var template = await _client.CreateTemplateAsync("test template name", "Test Message - #{{testKey}}", "test html body");
 
-            var messages = Enumerable.Range(0, 10).Select(k => BuildTemplatedMessage(template.TemplateId, k)).ToArray();
+            var messages = Enumerable.Range(0, 10)
+                .Select(k => BuildTemplatedMessage(template.TemplateId, k.ToString())).ToArray();
 
             var results = (await _client.SendEmailsWithTemplateAsync(messages)).ToList();
 
@@ -231,7 +232,7 @@ namespace Postmark.Tests
             Assert.Equal(messages.Length, results.Count());
         }
 
-        private TemplatedPostmarkMessage BuildTemplatedMessage(long templateId, int testValue = 0)
+        private TemplatedPostmarkMessage BuildTemplatedMessage(long templateId, string testValue)
         {
             var message = new TemplatedPostmarkMessage
             {
@@ -243,7 +244,7 @@ namespace Postmark.Tests
                 {
                     new MailHeader( "X-Integration-Testing-Postmark-Type-Message" , TESTING_DATE.ToString("o"))
                 },
-                Metadata = new Dictionary<string, string> { { "stuff", "very-interesting" }, { "client-id", "42" } },
+                Metadata = new Dictionary<string, string> { { "test-key", "test-value" }, { "client-id", "42" } },
                 Tag = "integration-testing"
             };
 

--- a/src/Postmark.Tests/Postmark.Tests.csproj
+++ b/src/Postmark.Tests/Postmark.Tests.csproj
@@ -6,8 +6,11 @@
     <StartupObject />
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="xunit" Version="*" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="*" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Postmark\Postmark.csproj" />

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -861,7 +861,7 @@ namespace PostmarkDotNet
         /// <summary>
         /// Sends a batch of up to 500 templated messages through the Postmark API.
         /// All email addresses must be valid, and the sender must be a valid sender signature according to Postmark.
-        /// Either the TemplateID or the TemplateAlias must be provided for each TemplatedPostmarkMessage.
+        /// Either the TemplateId or the TemplateAlias must be provided for each TemplatedPostmarkMessage.
         /// </summary>
         /// <param name="messages">A prepared batch of templated messages.</param>
         /// <returns>The processed messages (Complete with system assigned message IDs)</returns>
@@ -873,7 +873,7 @@ namespace PostmarkDotNet
         /// <summary>
         /// Sends a batch of up to 500 templated messages through the Postmark API.
         /// All email addresses must be valid, and the sender must be a valid sender signature according to Postmark.
-        /// Either the TemplateID or the TemplateAlias must be provided for each TemplatedPostmarkMessage.
+        /// Either the TemplateId or the TemplateAlias must be provided for each TemplatedPostmarkMessage.
         /// </summary>
         /// <param name="messages">A prepared batch of templated messages.</param>
         /// <returns>The processed messages (Complete with system assigned message IDs)</returns>

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -858,6 +858,32 @@ namespace PostmarkDotNet
             return await ProcessRequestAsync<TemplatedPostmarkMessage, PostmarkResponse>("/email/withTemplate", HttpMethod.Post, emailToSend);
         }
 
+        /// <summary>
+        /// Sends a batch of up to 500 templated messages through the Postmark API.
+        /// All email addresses must be valid, and the sender must be a valid sender signature according to Postmark.
+        /// Either the TemplateID or the TemplateAlias must be provided for each TemplatedPostmarkMessage.
+        /// </summary>
+        /// <param name="messages">A prepared batch of templated messages.</param>
+        /// <returns>The processed messages (Complete with system assigned message IDs)</returns>
+        public async Task<IEnumerable<PostmarkResponse>> SendMessagesAsync(params TemplatedPostmarkMessage[] messages)
+        {
+            return await SendEmailsWithTemplateAsync(messages);
+        }
+
+        /// <summary>
+        /// Sends a batch of up to 500 templated messages through the Postmark API.
+        /// All email addresses must be valid, and the sender must be a valid sender signature according to Postmark.
+        /// Either the TemplateID or the TemplateAlias must be provided for each TemplatedPostmarkMessage.
+        /// </summary>
+        /// <param name="messages">A prepared batch of templated messages.</param>
+        /// <returns>The processed messages (Complete with system assigned message IDs)</returns>
+        public async Task<IEnumerable<PostmarkResponse>> SendEmailsWithTemplateAsync(params TemplatedPostmarkMessage[] messages)
+        {
+            var body = new Dictionary<string, object> { ["Messages"] = messages.ToList() };
+
+            return await ProcessRequestAsync<Dictionary<string, object>, PostmarkResponse[]>("/email/batchWithTemplates", HttpMethod.Post, body);
+        }
+
         public async Task<PostmarkResponse> SendEmailWithTemplateAsync<T>(string templateAlias, T templateModel,
             string to, string from,
             bool? inlineCss = null, string cc = null,


### PR DESCRIPTION
- This PR adds support for sending batch templated messages via the `/email/batchWithTemplates` API endpoint.