### PR TITLE
Use api-ssl-temp.postmarkapp.com instead of api.postmarkapp.com

### DIFF
--- a/src/Postmark/PostmarkAdminClient.cs
+++ b/src/Postmark/PostmarkAdminClient.cs
@@ -19,7 +19,7 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="accountToken">The "accountToken" can be found by logging into your Postmark and navigating to https://postmarkapp.com/account/edit - Keep this token secret and safe.</param>
         /// <param name="apiBaseUri">Optionally override the base url to the API. For example, you may fallback to HTTP (non-SSL) if your app requires it, though, this is not recommended.</param>
-        public PostmarkAdminClient(string accountToken, string apiBaseUri = "https://api.postmarkapp.com")
+        public PostmarkAdminClient(string accountToken, string apiBaseUri = "https://api-ssl-temp.postmarkapp.com")
             : base(apiBaseUri)
         {
             _authToken = accountToken;

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -33,7 +33,7 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="apiBaseUri">The base uri to use when connecting to Postmark. You should rarely need to modify this, except if you want to disable TLS (not recommended), or you are using a proxy of some sort to connect to the API.</param>
         /// <param name="serverToken">Used for requests that require server level privileges. This token can be found on the Credentials tab under your Postmark server.</param>
-        public PostmarkClient(string serverToken, string apiBaseUri = "https://api.postmarkapp.com")
+        public PostmarkClient(string serverToken, string apiBaseUri = "https://api-ssl-temp.postmarkapp.com")
             : base(apiBaseUri)
         {
             _authToken = serverToken;

--- a/src/Postmark/PostmarkClientBase.cs
+++ b/src/Postmark/PostmarkClientBase.cs
@@ -44,7 +44,7 @@ namespace PostmarkDotNet
         /// </summary>
         /// <param name="apiBaseUri"></param>
         /// <param name="requestTimeoutInSeconds"></param>
-        public PostmarkClientBase(string apiBaseUri = "https://api.postmarkapp.com")
+        public PostmarkClientBase(string apiBaseUri = "https://api-ssl-temp.postmarkapp.com")
         {
             baseUri = new Uri(apiBaseUri);
         }


### PR DESCRIPTION
As suggested by Postmark in https://postmarkapp.com/updates/upcoming-tls-configuration-changes-for-api-users-action-may-be-required