### PR TITLE
Ability to apply a CC address

### DIFF
--- a/src/Postmark.Tests/ClientSendingTests.cs
+++ b/src/Postmark.Tests/ClientSendingTests.cs
@@ -43,6 +43,28 @@ namespace Postmark.Tests
                 "If it has been more than 45 days since these tests have been run on this server, try re-running this test."
             );
         }
+        
+        [Fact]
+        public async void Client_CanSendASingleMessage_With_CC()
+        {
+            var result = await _client.SendMessageAsync(WRITE_TEST_SENDER_EMAIL_ADDRESS,
+                WRITE_TEST_EMAIL_RECIPIENT_ADDRESS,
+                String.Format("Integration Test - {0}", TESTING_DATE),
+                String.Format("Plain text body, {0}", TESTING_DATE),
+                String.Format("Testing the Postmark .net client, <b>{0}</b>", TESTING_DATE),
+                new Dictionary<string, string>()
+                {
+                    {  "X-Integration-Testing" , TESTING_DATE.ToString("o")}
+                },
+                new Dictionary<string, string>() {
+                    {"test-metadata", "value-goes-here"},
+                    {"more-metadata", "more-goes-here"}
+                }, cc: WRITE_TEST_EMAIL_RECIPIENT_ADDRESS);
+
+            Assert.Equal(PostmarkStatus.Success, result.Status);
+            Assert.Equal(0, result.ErrorCode);
+            Assert.NotEqual(Guid.Empty, result.MessageID);
+        }
 
         [Fact]
         public async void Client_CanSendASingleMessage()

--- a/src/Postmark/Model/PostmarkMessage.cs
+++ b/src/Postmark/Model/PostmarkMessage.cs
@@ -23,8 +23,9 @@ namespace PostmarkDotNet
         /// <param name = "headers">A collection of additional mail headers to send with the message. (optional)</param>
         /// <param name = "metadata">A dictionary of metadata to send with the message. (optional)</param>
         /// <param name="messageStream">The message stream used to send this message. If not provided, the default transactional stream "outbound" will be used. (optional)</param>
+        /// <param name="cc">An email address for a CC recipient.</param>
         public PostmarkMessage(string from, string to, string subject, string textBody, string htmlBody,
-            HeaderCollection headers = null, IDictionary<string, string> metadata = null, string messageStream = null) : base()
+            HeaderCollection headers = null, IDictionary<string, string> metadata = null, string messageStream = null, string cc = null) : base()
         {
             From = from;
             To = to;
@@ -34,6 +35,7 @@ namespace PostmarkDotNet
             Headers = headers ?? new HeaderCollection();
             Metadata = metadata;
             MessageStream = messageStream;
+            Cc = cc;
         }
 
         /// <summary>

--- a/src/Postmark/PostmarkClientExtensions.cs
+++ b/src/Postmark/PostmarkClientExtensions.cs
@@ -25,15 +25,16 @@ namespace PostmarkDotNet
         /// <param name="htmlBody">The HTML Body to be used for the message, this may be null if TextBody is set.</param>
         /// <param name="headers">A collection of additional mail headers to send with the message.</param>
         /// <param name="messageStream">The message stream used to send this message.</param>
+        /// <param name="cc">An email address for a CC recipient.</param>
         /// <returns>A <see cref = "PostmarkResponse" /> with details about the transaction.</returns>
         public static async Task<PostmarkResponse> SendMessageAsync(this PostmarkClient client,
             string from, string to, string subject, string textBody, string htmlBody,
              IDictionary<string, string> headers = null,
              IDictionary<string, string> metadata = null,
-             string messageStream = null)
+             string messageStream = null, string cc = null)
         {
             var message = new PostmarkMessage(from, to, subject, textBody, htmlBody,
-            new HeaderCollection(headers), metadata, messageStream);
+            new HeaderCollection(headers), metadata, messageStream, cc);
             return await client.SendMessageAsync(message);
         }
 


### PR DESCRIPTION
The CC field is supported by the API, and the PostmarkMessage is simply JSON serialised to form the request to the Postmark API, so simply provide the CC field to enable CC capability.