### PR TITLE
PMK-2659 - Add Bulk Email API support (POST /email/bulk, GET /email/b…

### DIFF
--- a/src/Postmark.Tests/ClientBulkSendingTests.cs
+++ b/src/Postmark.Tests/ClientBulkSendingTests.cs
@@ -1,0 +1,92 @@
+using Xunit;
+using PostmarkDotNet;
+using PostmarkDotNet.Model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Postmark.Tests
+{
+    public class ClientBulkSendingTests : ClientBaseFixture
+    {
+        public ClientBulkSendingTests()
+        {
+            Client = new PostmarkClient(WriteTestServerToken, BaseUrl);
+        }
+
+        private PostmarkBulkMessage ConstructBulkMessage(int recipientCount = 3)
+        {
+            var message = new PostmarkBulkMessage
+            {
+                From = WriteTestSenderEmailAddress,
+                Subject = $"Bulk Integration Test - {TestingDate} - Hi {{{{FirstName}}}}",
+                HtmlBody = "<html><body>Hi, {{FirstName}}!</body></html>",
+                TextBody = "Hi, {{FirstName}}!",
+                MessageStream = "broadcast",
+                Tag = "bulk-integration-testing",
+                TrackOpens = true,
+                TrackLinks = LinkTrackingOptions.HtmlAndText,
+                Metadata = new Dictionary<string, string> { { "campaign", "integration" } },
+                Headers = new HeaderCollection
+                {
+                    new MailHeader("X-Integration-Testing-Postmark-Type-Message", TestingDate.ToString("o"))
+                },
+                Messages = Enumerable.Range(0, recipientCount)
+                    .Select(k => new PostmarkBulkMessageRecipient
+                    {
+                        To = WriteTestEmailRecipientAddress,
+                        TemplateModel = new Dictionary<string, object> { { "FirstName", $"Recipient{k}" } }
+                    })
+                    .ToList()
+            };
+
+            return message;
+        }
+
+        [Fact]
+        public async void Client_CanSendABulkEmail()
+        {
+            var result = await Client.SendBulkEmailAsync(ConstructBulkMessage(3));
+
+            Assert.Equal("Accepted", result.Status);
+            Assert.False(string.IsNullOrWhiteSpace(result.Id));
+            Assert.NotEqual(default, result.SubmittedAt);
+            Assert.Equal(3, result.TotalMessages);
+        }
+
+        [Fact]
+        public async void Client_CanRetrieveBulkEmailStatus()
+        {
+            var sendResult = await Client.SendBulkEmailAsync(ConstructBulkMessage());
+
+            var status = await Client.GetBulkEmailStatusAsync(sendResult.Id);
+
+            Assert.Equal(sendResult.Id, status.Id);
+            Assert.False(string.IsNullOrWhiteSpace(status.Status));
+            Assert.True(status.TotalMessages > 0);
+            Assert.True(status.PercentageCompleted >= 0 && status.PercentageCompleted <= 100);
+        }
+
+        [Fact]
+        public async void Client_CanSendABulkEmailWithoutTemplateModel()
+        {
+            var message = new PostmarkBulkMessage
+            {
+                From = WriteTestSenderEmailAddress,
+                Subject = $"Bulk Integration Test (no model) - {TestingDate}",
+                HtmlBody = $"<html><body>Testing the Postmark .net bulk client, <b>{TestingDate}</b></body></html>",
+                TextBody = "This is plain text.",
+                MessageStream = "broadcast",
+                Messages = new List<PostmarkBulkMessageRecipient>
+                {
+                    new PostmarkBulkMessageRecipient { To = WriteTestEmailRecipientAddress }
+                }
+            };
+
+            var result = await Client.SendBulkEmailAsync(message);
+
+            Assert.Equal("Accepted", result.Status);
+            Assert.False(string.IsNullOrWhiteSpace(result.Id));
+        }
+    }
+}

--- a/src/Postmark/Model/PostmarkBulkEmailStatus.cs
+++ b/src/Postmark/Model/PostmarkBulkEmailStatus.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Text.Json.Serialization;
+
+namespace PostmarkDotNet
+{
+    /// <summary>
+    /// The status/progress of a bulk email request (<c>GET /email/bulk/{bulk-request-id}</c>).
+    /// </summary>
+    public class PostmarkBulkEmailStatus
+    {
+        /// <summary>
+        ///   The identifier of the bulk request.
+        /// </summary>
+        [JsonPropertyName("Id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        ///   The time the request was received by Postmark.
+        /// </summary>
+        public DateTime SubmittedAt { get; set; }
+
+        /// <summary>
+        ///   The total number of messages contained in the request.
+        /// </summary>
+        public int TotalMessages { get; set; }
+
+        /// <summary>
+        ///   The percentage of the request that has been processed, from 0 to 100.
+        /// </summary>
+        public double PercentageCompleted { get; set; }
+
+        /// <summary>
+        ///   The processing status of the request.
+        ///   One of "Accepted", "Processing", "Completed", or "Cancelled".
+        /// </summary>
+        public string Status { get; set; }
+
+        /// <summary>
+        ///   The subject line of the messages in the request.
+        /// </summary>
+        public string Subject { get; set; }
+    }
+}

--- a/src/Postmark/Model/PostmarkBulkMessage.cs
+++ b/src/Postmark/Model/PostmarkBulkMessage.cs
@@ -1,0 +1,168 @@
+using PostmarkDotNet.Model;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace PostmarkDotNet
+{
+    /// <summary>
+    /// A message destined for the Postmark Bulk Email API (<c>POST /email/bulk</c>).
+    /// </summary>
+    /// <remarks>
+    /// The Bulk Email API is intended for broadcast/marketing sends (newsletters, announcements).
+    /// This is distinct from the transactional batch endpoints (<c>/email/batch</c>,
+    /// <c>/email/batchWithTemplates</c>): a single message definition is supplied here, and each entry in
+    /// <see cref="Messages"/> provides its own recipient addressing and per-recipient template values.
+    /// The request is accepted for asynchronous processing; use
+    /// <see cref="PostmarkClient.GetBulkEmailStatusAsync"/> to track progress.
+    /// </remarks>
+    public class PostmarkBulkMessage
+    {
+        public PostmarkBulkMessage()
+        {
+            Attachments = new List<PostmarkMessageAttachment>(0);
+            Messages = new List<PostmarkBulkMessageRecipient>();
+            TrackLinks = LinkTrackingOptions.None;
+        }
+
+        /// <summary>
+        ///   The message stream used to send this message. Defaults to the server's broadcast stream.
+        /// </summary>
+        public string MessageStream { get; set; }
+
+        /// <summary>
+        ///   The sender's email address. Must be a valid sender signature. Required.
+        /// </summary>
+        public string From { get; set; }
+
+        /// <summary>
+        ///   The email address to reply to. This is optional.
+        /// </summary>
+        public string ReplyTo { get; set; }
+
+        /// <summary>
+        ///   The message subject line. May contain template placeholders when using inline content.
+        /// </summary>
+        public string Subject { get; set; }
+
+        /// <summary>
+        ///   The HTML body of the message. May be null if <see cref="TextBody"/> or a template is used.
+        /// </summary>
+        public string HtmlBody { get; set; }
+
+        /// <summary>
+        ///   The plain text body of the message. May be null if <see cref="HtmlBody"/> or a template is used.
+        /// </summary>
+        public string TextBody { get; set; }
+
+        /// <summary>
+        ///   The id of a hosted template to use when sending this message.
+        ///   Either this or <see cref="TemplateAlias"/> may be provided; TemplateId takes precedence when both are set.
+        /// </summary>
+        public long? TemplateId { get; set; }
+
+        /// <summary>
+        ///   The alias of a hosted template to use when sending this message.
+        ///   Either this or <see cref="TemplateId"/> may be provided; TemplateId takes precedence when both are set.
+        /// </summary>
+        public string TemplateAlias { get; set; }
+
+        /// <summary>
+        ///   Should the CSS in the HtmlBody (or template) be inlined? Defaults to true.
+        /// </summary>
+        public bool InlineCss { get; set; } = true;
+
+        /// <summary>
+        ///   An optional message tag, used for breaking down statistics in the Postmark UI.
+        /// </summary>
+        public string Tag { get; set; }
+
+        /// <summary>
+        ///   A dictionary of optional metadata applied to every recipient.
+        ///   Individual recipients may override this via <see cref="PostmarkBulkMessageRecipient.Metadata"/>.
+        /// </summary>
+        public IDictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        ///   Track these messages using Postmark's OpenTracking feature.
+        /// </summary>
+        public bool? TrackOpens { get; set; }
+
+        /// <summary>
+        ///   Track these messages using Postmark's LinkTracking feature.
+        /// </summary>
+        public LinkTrackingOptions? TrackLinks { get; set; }
+
+        /// <summary>
+        ///   A collection of optional message headers applied to every recipient.
+        /// </summary>
+        public HeaderCollection Headers { get; set; } = new HeaderCollection();
+
+        /// <summary>
+        ///   A collection of optional file attachments applied to every recipient.
+        /// </summary>
+        public ICollection<PostmarkMessageAttachment> Attachments { get; set; }
+
+        /// <summary>
+        ///   The per-recipient messages to send. Postmark accepts an unlimited number of recipients per
+        ///   call, subject to the 50 MB total payload limit (including attachments). Required.
+        /// </summary>
+        public ICollection<PostmarkBulkMessageRecipient> Messages { get; set; }
+
+        private static byte[] ReadStream(Stream input, int bufferSize)
+        {
+            var buffer = new byte[bufferSize];
+            using (var ms = new MemoryStream())
+            {
+                int read;
+                while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+                {
+                    ms.Write(buffer, 0, read);
+                }
+                return ms.ToArray();
+            }
+        }
+
+        /// <summary>
+        ///  Adds a file attachment stream with inline support.
+        /// </summary>
+        /// <param name = "contentStream">An opened stream of the file attachment.</param>
+        /// <param name="attachmentName">The file name associated with the attachment.</param>
+        /// <param name = "contentType">The content type.</param>
+        /// <param name="contentId">The ContentId for inlined images.</param>
+        public void AddAttachment(Stream contentStream, string attachmentName, string contentType = "application/octet-stream", string contentId = null)
+        {
+            var content = ReadStream(contentStream, 8067);
+            var payload = Convert.ToBase64String(content);
+
+            var attachment = new PostmarkMessageAttachment
+            {
+                Name = attachmentName,
+                ContentType = contentType,
+                Content = payload
+            };
+
+            if ((contentId?.Trim() ?? "") != null)
+            {
+                attachment.ContentId = contentId;
+            }
+
+            Attachments.Add(attachment);
+        }
+
+        /// <summary>
+        ///  Adds a file attachment using a byte[] array with inline support.
+        /// </summary>
+        /// <param name="content"> The file contents.</param>
+        /// <param name="attachmentName">The file name of the attachment.</param>
+        /// <param name = "contentType">The content type.</param>
+        /// <param name = "contentId">The ContentId for inline images.</param>
+        public void AddAttachment(byte[] content, string attachmentName, string contentType = "application/octet-stream", string contentId = null)
+        {
+            using (var ms = new MemoryStream(content))
+            {
+                this.AddAttachment(ms, attachmentName, contentType, contentId);
+            }
+        }
+    }
+}

--- a/src/Postmark/Model/PostmarkBulkMessageRecipient.cs
+++ b/src/Postmark/Model/PostmarkBulkMessageRecipient.cs
@@ -1,0 +1,56 @@
+using PostmarkDotNet.Model;
+using System.Collections.Generic;
+using System.Text.Json.Serialization;
+
+namespace PostmarkDotNet
+{
+    /// <summary>
+    /// A single recipient entry in a <see cref="PostmarkBulkMessage"/>.
+    /// The shared message content (From, Subject, Body/Template, etc.) is defined once on the
+    /// parent <see cref="PostmarkBulkMessage"/>; each recipient supplies its own addressing and
+    /// per-recipient template values.
+    /// </summary>
+    /// <remarks>
+    /// The Bulk API validates recipient objects strictly and rejects fields that are present but null,
+    /// so optional properties are omitted from the serialized payload when not set.
+    /// </remarks>
+    public class PostmarkBulkMessageRecipient
+    {
+        /// <summary>
+        ///   Any recipients. Separate multiple recipients with a comma (up to 50 addresses).
+        /// </summary>
+        public string To { get; set; }
+
+        /// <summary>
+        ///   Any CC recipients. Separate multiple recipients with a comma (up to 50 addresses).
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string Cc { get; set; }
+
+        /// <summary>
+        ///   Any BCC recipients. Separate multiple recipients with a comma (up to 50 addresses).
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public string Bcc { get; set; }
+
+        /// <summary>
+        ///   The values to merge with the template (or inline body) for this specific recipient.
+        ///   Must be a JSON object (e.g. a Dictionary&lt;string, object&gt;, POCO, or anonymous type).
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public object TemplateModel { get; set; }
+
+        /// <summary>
+        ///   A dictionary of optional metadata for this recipient. If provided, this overrides
+        ///   any metadata specified on the parent <see cref="PostmarkBulkMessage"/>.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public IDictionary<string, string> Metadata { get; set; }
+
+        /// <summary>
+        ///   A collection of optional message headers for this recipient.
+        /// </summary>
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        public HeaderCollection Headers { get; set; }
+    }
+}

--- a/src/Postmark/Postmark.csproj
+++ b/src/Postmark/Postmark.csproj
@@ -6,7 +6,7 @@
     <PackageIconUrl>https://github.com/wildbit/postmark-dotnet/raw/master/postmark-logo.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/wildbit/postmark-dotnet.git</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <Version>3.4</Version>
+    <Version>5.4.0</Version>
     <Company>Wildbit, LLC.</Company>
     <Description>The official .net client for Postmark.</Description>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/src/Postmark/PostmarkClient.cs
+++ b/src/Postmark/PostmarkClient.cs
@@ -67,6 +67,35 @@ namespace PostmarkDotNet
         {
             return await ProcessRequestAsync<PostmarkMessage[], PostmarkResponse[]>("/email/batch", HttpMethod.Post, messages);
         }
+
+        /// <summary>
+        /// Sends a bulk email through the Postmark API (POST /email/bulk).
+        /// This endpoint is intended for broadcast/marketing sends (newsletters, announcements) and is
+        /// distinct from the transactional batch endpoints. A single message definition is supplied,
+        /// and each entry in <see cref="PostmarkBulkMessage.Messages"/> provides its own recipient
+        /// addressing and per-recipient template values. Postmark accepts an unlimited number of
+        /// recipients per call, subject to the 50 MB total payload limit.
+        /// </summary>
+        /// <param name="message">A prepared bulk message.</param>
+        /// <returns>The initial status of the accepted bulk request, including the id
+        /// (<see cref="PostmarkBulkEmailStatus.Id"/>) used to track its progress.</returns>
+        /// <seealso cref="GetBulkEmailStatusAsync"/>
+        public async Task<PostmarkBulkEmailStatus> SendBulkEmailAsync(PostmarkBulkMessage message)
+        {
+            return await ProcessRequestAsync<PostmarkBulkMessage, PostmarkBulkEmailStatus>("/email/bulk", HttpMethod.Post, message);
+        }
+
+        /// <summary>
+        /// Retrieves the status/progress of a previously submitted bulk email request
+        /// (GET /email/bulk/{bulk-request-id}).
+        /// </summary>
+        /// <param name="bulkRequestId">The id returned from <see cref="SendBulkEmailAsync"/>.</param>
+        /// <returns>The current status and completion progress of the bulk request.</returns>
+        /// <seealso cref="SendBulkEmailAsync"/>
+        public async Task<PostmarkBulkEmailStatus> GetBulkEmailStatusAsync(string bulkRequestId)
+        {
+            return await ProcessNoBodyRequestAsync<PostmarkBulkEmailStatus>("/email/bulk/" + bulkRequestId);
+        }
         #endregion
 
         #region Bounces


### PR DESCRIPTION
Adds broadcast/marketing bulk send support, distinct from the transactional batch endpoints:

- SendBulkEmailAsync(PostmarkBulkMessage) -> POST /email/bulk
- GetBulkEmailStatusAsync(string bulkRequestId) -> GET /email/bulk/{id}

A single message definition (PostmarkBulkMessage) carries shared content and a Messages collection of per-recipient entries (PostmarkBulkMessageRecipient) with per-recipient TemplateModel/addressing. Both endpoints return the same PostmarkBulkEmailStatus payload (Id, SubmittedAt, TotalMessages, PercentageCompleted, Status, Subject).